### PR TITLE
Added a splitter that filters by site

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,9 @@
 # download data for each site
+get_state_inventory <- function(sites_info, state) {
+  site_info <- dplyr::filter(sites_info, state_cd == state)
+}
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/_targets.R
+++ b/_targets.R
@@ -11,8 +11,9 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL')
+states <- c('WI','MN','MI', 'IL', "IN", "IA")
 parameter <- c('00060')
+
 
 # Targets
 list(
@@ -20,8 +21,9 @@ list(
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
 
   tar_map(
-    values = tibble(state_abb = states),
-    tar_target(nwis_data, get_site_data(oldest_active_sites, state_abb, parameter))
+    values = tibble(state_cd = states),
+    tar_target(nwis_inventory, get_state_inventory(oldest_active_sites, state_cd)),
+    tar_target(nwis_data, get_site_data(nwis_inventory, state_cd, parameter))
   ),
 
 


### PR DESCRIPTION
 Used a splitter so the pipeline doesn't need to download older individual states when you add new ones to the list.
When I added Indiana and Iowa, the pipeline skipped building:
✓ skip target nwis_data_MI
✓ skip target nwis_data_WI
✓ skip target nwis_data_MN
✓ skip target nwis_data_IL
